### PR TITLE
Added support for sites without a region

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ session:
     # Set default credentials; they should be defined in SecureCRT beforehand under "Preferences -> General -> Credentials"
     credential: <username>
     # Set a firewall; supports templates and expressions
-    firewall: "{{ FindTag(device.Tags, 'connection_firewall') ?? null }}"
+    firewall: "{{ FindTag(device.Tags, 'connection_firewall') ?? ''None'' }}"
 
   # Overrides based on conditions
   # target can be one of: path, device_name, description, connection_protocol, credential, firewall
@@ -117,7 +117,7 @@ session:
       value: _Stores/{region_name}/{site_name}
 
     - target: path
-      condition: "{{ type == 'virtual_machine' }}"
+      condition: "{{ device_type == 'virtual_machine' }}"
       value: _Servers/{region_name}
     
     # device_name override use cases include removing domain names, extra values like .1, and so on

--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -51,6 +51,13 @@ func (i *InventorySync) getSite(sites []*models.Site, siteID int64) (*models.Sit
 	return nil, ErrorFailedToFindSite
 }
 
+func (i *InventorySync) getRegionName(site *models.Site) string {
+	if site.Region != nil && site.Region.Name != nil {
+		return *site.Region.Name
+	}
+	return "No Region"
+}
+
 func (i *InventorySync) getTenant(device interface{}) string {
 	nd, ok := device.(*models.DeviceWithConfigContext)
 	if ok && nd != nil && nd.Tenant != nil {
@@ -94,6 +101,7 @@ func (i *InventorySync) getDeviceSessions(devices []*models.DeviceWithConfigCont
 		}
 
 		tenant := i.getTenant(device)
+		regionName := i.getRegionName(site)
 		ipAddress := strings.Split(*device.PrimaryIp4.Address, "/")[0]
 		siteAddress := strings.ReplaceAll(site.PhysicalAddress, "\r\n", ", ")
 		deviceType := device.DeviceType.Display
@@ -108,7 +116,7 @@ func (i *InventorySync) getDeviceSessions(devices []*models.DeviceWithConfigCont
 		env.DeviceRole = *device.DeviceRole.Name
 		env.DeviceType = deviceType
 		env.DeviceIP = ipAddress
-		env.RegionName = *site.Region.Name
+		env.RegionName = regionName
 		env.TenantName = tenant
 		env.Site = site
 		env.SiteName = site.Display
@@ -141,6 +149,7 @@ func (i *InventorySync) getVirtualMachineSessions(devices []*models.VirtualMachi
 		}
 
 		tenant := i.getTenant(device)
+		regionName := i.getRegionName(site)
 		ipAddress := strings.Split(*device.PrimaryIp4.Address, "/")[0]
 		siteAddress := strings.ReplaceAll(site.PhysicalAddress, "\r\n", ", ")
 		deviceType := ""
@@ -159,7 +168,7 @@ func (i *InventorySync) getVirtualMachineSessions(devices []*models.VirtualMachi
 		env.DeviceRole = "Virtual Machine"
 		env.DeviceType = deviceType
 		env.DeviceIP = ipAddress
-		env.RegionName = *site.Region.Name
+		env.RegionName = regionName
 		env.TenantName = tenant
 		env.Site = site
 		env.SiteName = site.Display


### PR DESCRIPTION
Added new function within internal/inventory/inventory.go in order to handle sites without a region.
It *should* have the same behaviour as the function for tenants.