### PR TITLE
Added support for virtual chassis

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ tenant_name: Tenant name from NetBox
 site_name: Site name from NetBox
 site_group: Site Group name from NetBox
 site_address: Site address from NetBox
+virtual_chassis_name: Virtual Chassis name from NetBox
 ```
 
 ### Expressions
@@ -70,7 +71,7 @@ site: The site object  (go struct, most fields are CamelCase, ex: site.Slug)
 
 Expressions have access to all expr functions and the following:
 ```
-FindTag(<tags>, <tag_name)
+FindTag(<tags>, <tag_name>)
 ```
 
 ### Debug

--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -109,6 +109,10 @@ func (i *InventorySync) getDeviceSessions(devices []*models.DeviceWithConfigCont
 		if site.Group != nil {
 			siteGroup = *site.Group.Slug
 		}
+		virtualChassisName := ""
+		if device.VirtualChassis != nil {
+			virtualChassisName = *device.VirtualChassis.Name
+		}
 
 		env := i.getCommonEnvironment("device")
 		env.Device = device
@@ -122,6 +126,7 @@ func (i *InventorySync) getDeviceSessions(devices []*models.DeviceWithConfigCont
 		env.SiteName = site.Display
 		env.SiteGroup = siteGroup
 		env.SiteAddress = siteAddress
+		env.VirtualChassisName = virtualChassisName
 
 		err = applyOverrides(i.cfg.Session.Overrides, env)
 		if err != nil {

--- a/pkg/evaluator/environment.go
+++ b/pkg/evaluator/environment.go
@@ -27,6 +27,7 @@ type Environment struct {
 	SiteName                   string `expr:"site_name"`
 	SiteGroup                  string `expr:"site_group"`
 	SiteAddress                string `expr:"site_address"`
+	VirtualChassisName         string `expr:"virtual_chassis_name"`
 
 	Device interface{} `expr:"device"`
 	Site   interface{} `expr:"site"`


### PR DESCRIPTION
Extended getDeviceSessions with device.VirtualChassis.Name
When a device is part of a VC in NetBox `virtual_chassis_name` will be populated, which can be used in overwrites.